### PR TITLE
Feat: Introduce oh-vue-icons & 'Info' alert type

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "snackfy-vue",
       "version": "0.0.0",
       "dependencies": {
+        "oh-vue-icons": "^1.0.0-rc3",
         "vue": "^3.4.21"
       },
       "devDependencies": {
@@ -3318,6 +3319,48 @@
       },
       "funding": {
         "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/oh-vue-icons": {
+      "version": "1.0.0-rc3",
+      "resolved": "https://registry.npmjs.org/oh-vue-icons/-/oh-vue-icons-1.0.0-rc3.tgz",
+      "integrity": "sha512-+k2YC6piK7sEZnwbkQF3UokFPMmgqpiLP6f/H0ovQFLl20QA5V4U8EcI6EclD2Lt5NMQ3k6ilLGo8XyXqdVSvg==",
+      "dependencies": {
+        "vue-demi": "^0.12.5"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^2.0.0 || >=3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/oh-vue-icons/node_modules/vue-demi": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.12.5.tgz",
+      "integrity": "sha512-BREuTgTYlUr0zw0EZn3hnhC3I6gPWv+Kwh4MCih6QcAeaTlaIX0DwOVN0wHej7hSvDPecz4jygy/idsgKfW58Q==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/once": {

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "format": "prettier --write src/"
   },
   "dependencies": {
+    "oh-vue-icons": "^1.0.0-rc3",
     "vue": "^3.4.21"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -29,6 +29,7 @@
         <label for="type">Type</label>
         <select id="type" v-model="type">
           <option value="success">Success</option>
+          <option value="info">Info</option>
           <option value="error">Error</option>
         </select>
       </div>

--- a/src/components/Snackbar.vue
+++ b/src/components/Snackbar.vue
@@ -32,6 +32,7 @@
     bottom: 1rem;
     right: 1rem;
     max-width: 330px;
+    min-width: 300px;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;

--- a/src/components/SnackfyVue.vue
+++ b/src/components/SnackfyVue.vue
@@ -6,6 +6,8 @@
   import {
     SUCCESS_COLOR,
     ERROR_COLOR,
+    SUCCESS_ICON,
+    ERROR_ICON,
     DEFAULT_DURATION,
     DURATION_OFFSET_IN_MS
   } from '../constants';
@@ -19,6 +21,9 @@
   /* Computed */
   const notificationColor = computed(() => {
     return _type.value === 'success' ? SUCCESS_COLOR : ERROR_COLOR;
+  });
+  const notificationIcon = computed(() => {
+    return _type.value === 'success' ? SUCCESS_ICON : ERROR_ICON;
   });
 
   function showNotification({
@@ -50,6 +55,12 @@
 <template>
   <Snackbar :isVisible="_isVisible" :duration="_duration">
     <div class="SnackfyVue-message-wrapper">
+      <v-icon
+        class="SnackfyVue-icon"
+        scale="1.5"
+        :name="notificationIcon"
+        :fill="notificationColor"
+      />
       <p class="SnackfyVue-message">{{ _message }}</p>
     </div>
     <LoadingBar :duration="_duration" :color="notificationColor" />
@@ -67,6 +78,5 @@
     font-size: 0.875rem;
     color: #323743ff;
     width: 100%;
-    text-align: center;
   }
 </style>

--- a/src/components/SnackfyVue.vue
+++ b/src/components/SnackfyVue.vue
@@ -5,8 +5,10 @@
   import type { NotificationType, ShowNotificationsProps } from '../types';
   import {
     SUCCESS_COLOR,
+    INFO_COLOR,
     ERROR_COLOR,
     SUCCESS_ICON,
+    INFO_ICON,
     ERROR_ICON,
     DEFAULT_DURATION,
     DURATION_OFFSET_IN_MS
@@ -15,20 +17,25 @@
   /* REFs */
   const _isVisible = ref<boolean>(false);
   const _message = ref<string>('');
-  const _type = ref<NotificationType>('success');
+  const _type = ref<NotificationType>('info');
   const _duration = ref<number>(DEFAULT_DURATION);
 
   /* Computed */
   const notificationColor = computed(() => {
-    return _type.value === 'success' ? SUCCESS_COLOR : ERROR_COLOR;
+    if (_type.value === 'success') return SUCCESS_COLOR;
+    if (_type.value === 'info') return INFO_COLOR;
+    return ERROR_COLOR;
   });
+
   const notificationIcon = computed(() => {
-    return _type.value === 'success' ? SUCCESS_ICON : ERROR_ICON;
+    if (_type.value === 'success') return SUCCESS_ICON;
+    if (_type.value === 'info') return INFO_ICON;
+    return ERROR_ICON;
   });
 
   function showNotification({
     message = '',
-    type = 'success' as NotificationType,
+    type = 'info' as NotificationType,
     duration = DEFAULT_DURATION
   }: ShowNotificationsProps) {
     _isVisible.value = true;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,7 +1,9 @@
 export const SUCCESS_COLOR = '#63b365';
+export const INFO_COLOR = '#5eafe6';
 export const ERROR_COLOR = '#f22e2e';
 
 export const SUCCESS_ICON = 'bi-check-circle-fill';
+export const INFO_ICON = 'bi-exclamation-lg';
 export const ERROR_ICON = 'bi-exclamation-triangle-fill';
 
 export const DEFAULT_DURATION = 2.5;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -3,7 +3,7 @@ export const INFO_COLOR = '#5eafe6';
 export const ERROR_COLOR = '#f22e2e';
 
 export const SUCCESS_ICON = 'bi-check-circle-fill';
-export const INFO_ICON = 'bi-exclamation-lg';
+export const INFO_ICON = 'bi-exclamation-circle-fill';
 export const ERROR_ICON = 'bi-exclamation-triangle-fill';
 
 export const DEFAULT_DURATION = 2.5;

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,9 @@
 export const SUCCESS_COLOR = '#63b365';
 export const ERROR_COLOR = '#f22e2e';
 
+export const SUCCESS_ICON = 'bi-check-circle-fill';
+export const ERROR_ICON = 'bi-exclamation-triangle-fill';
+
 export const DEFAULT_DURATION = 2.5;
 // offset to ensure the notification is removed after the animation plays out
 export const DURATION_OFFSET_IN_MS = 300;

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,10 +2,14 @@ import './assets/base.css';
 
 import { createApp } from 'vue';
 import { OhVueIcon, addIcons } from 'oh-vue-icons';
-import { BiCheckCircleFill, BiExclamationLg, BiExclamationTriangleFill } from 'oh-vue-icons/icons';
+import {
+  BiCheckCircleFill,
+  BiExclamationCircleFill,
+  BiExclamationTriangleFill
+} from 'oh-vue-icons/icons';
 import App from './App.vue';
 
-addIcons(BiCheckCircleFill, BiExclamationLg, BiExclamationTriangleFill);
+addIcons(BiCheckCircleFill, BiExclamationCircleFill, BiExclamationTriangleFill);
 
 const app = createApp(App);
 app.component('v-icon', OhVueIcon);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,8 +1,13 @@
 import './assets/base.css';
 
 import { createApp } from 'vue';
+import { OhVueIcon, addIcons } from 'oh-vue-icons';
+import { BiCheckCircleFill, BiExclamationLg, BiExclamationTriangleFill } from 'oh-vue-icons/icons';
 import App from './App.vue';
 
+addIcons(BiCheckCircleFill, BiExclamationLg, BiExclamationTriangleFill);
+
 const app = createApp(App);
+app.component('v-icon', OhVueIcon);
 
 app.mount('#app');

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-export type NotificationType = 'success' | 'error';
+export type NotificationType = 'success' | 'info' | 'error';
 export type ShowNotificationsProps = {
   message: string;
   type: NotificationType;


### PR DESCRIPTION
## Description
This PR introduces two main set of changes:
1. Add & setup `oh-vue-icons` - The setup is careful to only import the icons needed in order to reduce the bundle size.
2. Add `info` alert type - works similarly to `success` & `error`, but with a different color and icon

## Screenshots

### Long text
![image](https://github.com/ysoares0209/SnackfyVue/assets/48188972/4a0773b8-20a4-4b61-a141-100606ced56b)
![image](https://github.com/ysoares0209/SnackfyVue/assets/48188972/2ce69da6-180c-4f94-a77f-674a02f7e10c)


### Success
![image](https://github.com/ysoares0209/SnackfyVue/assets/48188972/d11a3bde-78e6-46f5-b5e4-417e82001c65)

### Info
![image](https://github.com/ysoares0209/SnackfyVue/assets/48188972/8d7b945b-f721-4e2e-a8c7-16e405f68c24)

### Error
![image](https://github.com/ysoares0209/SnackfyVue/assets/48188972/4f167805-e8b3-4eab-8b76-8fd19ea9e82b)
